### PR TITLE
Add the ability for a struct to contain a flag.Value type.

### DIFF
--- a/utils/setup.go
+++ b/utils/setup.go
@@ -63,7 +63,12 @@ func Setup(prefix string, x interface{}) {
 			flagName = fmt.Sprintf("%s.%s", prefix, flagName)
 		}
 		defaultStr, usage := getParams(ftyp.Tag)
-		switch fvar := field.Addr().Interface().(type) {
+		ivar := field.Addr().Interface()
+		if v, ok := ivar.(flag.Value); ok {
+			flag.Var(v, flagName, usage)
+			continue
+		}
+		switch fvar := ivar.(type) {
 		case *bool:
 			defaultVal, err := strconv.ParseBool(defaultStr)
 			if err != nil {


### PR DESCRIPTION
To allow custom types to be handled, test if the given structure member
implements the flag.Value interface.  If it does, use flag.Var function instead
of the usual flag.*Var functions.  This also allows standard types to be
overridden along with custom types.