### PR TITLE
Export Specific Flags

### DIFF
--- a/out.go
+++ b/out.go
@@ -92,4 +92,5 @@ func DumpToPath(path string) error {
 	}
 	defer fh.Close()
 	return Dump(fh)
+	
 }

--- a/out.go
+++ b/out.go
@@ -50,6 +50,35 @@ func Dump(out io.Writer) error {
 	})
 	return parser.Serialize(vals, out)
 }
+// DumpMyFlag will write all flags contained in the flags array to the given io.Writer in the flagfile
+// serialization format for later parsing.
+func DumpMyFlags(myflags []string,out io.Writer) error{
+	mtx.Lock()
+	defer mtx.Unlock()
+	vals := make(map[string]string)
+
+	flag.VisitAll(func (f *flag.Flag){
+		for _,flg := range myflags {
+			if f.Name == flg {
+				vals[f.Name] = f.Value.String()
+			}
+		}
+
+	})
+	return parser.Serialize(vals,out)
+}
+
+func DumpMyFlagsToPath(myflags []string,path string) error{
+	fh, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
+		0600)
+	if err != nil {
+		return err
+	}
+	defer fh.Close()
+
+	return DumpMyFlags(myflags,fh)
+}
+
 
 // DumpToPath simply calls Dump on a new filehandle (O_CREATE|O_TRUNC) for the
 // given path

--- a/out.go
+++ b/out.go
@@ -68,6 +68,8 @@ func DumpMyFlags(myflags []string,out io.Writer) error{
 	return parser.Serialize(vals,out)
 }
 
+// DumpToPath simply calls DumpMyFlags on a new filehandle (O_CREATE|O_TRUNC) for the
+// given path
 func DumpMyFlagsToPath(myflags []string,path string) error{
 	fh, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
 		0600)


### PR DESCRIPTION
Added the possibility to export specific flags (to io.writer or to file) in 2 functions: DumpMyFlags & DumpMyFlagsToPath. Each function takes a string array which contains the desired flags.